### PR TITLE
Fix handle leak and unhandeled exception in finalizer

### DIFF
--- a/IronFrame/ImpersonationProcessRunner.cs
+++ b/IronFrame/ImpersonationProcessRunner.cs
@@ -48,12 +48,20 @@ namespace IronFrame.Utilities
         public ImpersonationProcess(ProcessRunSpec runSpec)
         {
             this.runSpec = runSpec;
+            this.Handle = IntPtr.Zero;
         }
 
         ~ImpersonationProcess()
         {
-            if (!NativeMethods.CloseHandle(Handle))
-                throw new Win32Exception(Marshal.GetLastWin32Error());
+            if (this.Handle != IntPtr.Zero)
+            {
+                if (!NativeMethods.CloseHandle(Handle))
+                {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+
+                this.Handle = IntPtr.Zero;
+            }
         }
 
         public void Dispose()
@@ -156,6 +164,7 @@ namespace IronFrame.Utilities
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             NativeMethods.DestroyEnvironmentBlock(unmanagedEnv);
+            NativeMethods.CloseHandle(processInfo.hThread);
 
             Handle = processInfo.hProcess;
 


### PR DESCRIPTION
For the thread leak I just added a close statement after CreateProcess for the thread handle, as it is not used.

For the finalizer issue, I just changed the code to check if the handle was initialized. 
It actually happen in my dev env when I ran some load tests.

I am not sure how to write useful unit tests for this scenarios; I would appreciate any hints.

Finalizer error from event log:
```
Application: Containerizer.exe
Framework Version: v4.0.30319
Description: The process was terminated due to an unhandled exception.
Exception Info: System.ComponentModel.Win32Exception
   at IronFrame.Utilities.ImpersonationProcess.Finalize()
```