### PR TITLE
Deadlock fix

### DIFF
--- a/IronFrame.Test/ContainerHostClientTests.cs
+++ b/IronFrame.Test/ContainerHostClientTests.cs
@@ -86,6 +86,23 @@ namespace IronFrame
 
                 Assert.Same(ExpectedResult, result);
             }
+
+            [Fact]
+            public void WhenTimeoutOccurs_ThrowException()
+            {
+                var @params = new CreateProcessParams
+                {
+                    executablePath = "foo.exe",
+                };
+
+                MessagingClient.SendMessageAsync<CreateProcessRequest, CreateProcessResponse>(null)
+                    .ReturnsForAnyArgs(async (call) => {
+                        await Task.Delay(16 * 1000);
+                        return ExpectedResponse;
+                    });
+
+                Assert.Throws<TimeoutException>(() => { Client.CreateProcess(@params); });
+            }
         }
 
         public class Ping : ContainerHostClientTests

--- a/IronFrame/ContainerHostClient.cs
+++ b/IronFrame/ContainerHostClient.cs
@@ -24,6 +24,8 @@ namespace IronFrame
 
     internal class ContainerHostClient : IContainerHostClient
     {
+        private const int DefaultCreateProcessTimeout = 15 * 1000;
+
         JobObject containerJobObject;
         IProcess hostProcess;
         IMessageTransport messageTransport;
@@ -54,7 +56,13 @@ namespace IronFrame
 
         public CreateProcessResult CreateProcess(CreateProcessParams @params)
         {
-            var response = SendMessage<CreateProcessRequest, CreateProcessResponse>(new CreateProcessRequest(@params));
+            CreateProcessResponse response;
+
+            if (!TrySendMessage<CreateProcessRequest, CreateProcessResponse>(new CreateProcessRequest(@params), new TimeSpan(0, 0, 0, 0, DefaultCreateProcessTimeout), out response))
+            {
+                throw new TimeoutException("CreateProcess timed out");
+            }
+
             return response.result;
         }
 

--- a/IronFrame/ContainerHostService.cs
+++ b/IronFrame/ContainerHostService.cs
@@ -76,18 +76,18 @@ namespace IronFrame
                 Credentials = credentials,
             };
 
-            var hostProcess = processRunner.Run(hostRunSpec);
-
-            WaitForProcessToStart(hostProcess, HostProcessStartTimeout);
-
             // Order here is important.
-            // - Start the process and verify that it's running
+            // - Start the process 
             // - Add the process to the job object
+            // - Verify that the process is healthy
             // - Start the RPC message pump
             //
             // We need to ensure that the host process cannot create any new processes before
             // it's added to the job object.
+
+            var hostProcess = processRunner.Run(hostRunSpec);
             jobObject.AssignProcessToJob(hostProcess.Handle);
+            WaitForProcessToStart(hostProcess, HostProcessStartTimeout);
 
             var messageTransport = MessageTransport.Create(hostProcess.StandardOutput, hostProcess.StandardInput);
             var messagingClient = MessagingClient.Create(async message =>


### PR DESCRIPTION
There are 2 patches in this PR that solves some issues that can occurs after several hours of restarting apps continuously on a small windows cell.

- The first issue is a deadlock inside Container class that will prevent the container to get destroyed. After a thread dump I saw that the RunProcess RPC was stuck indefinitely for some reason and kept the Container's _ioLock lock alive ( https://github.com/cloudfoundry/IronFrame/blob/04b0bf6040c2dd00da09614d82f161e72509a1e0/IronFrame/Container.cs#L99 ). My proposed fix is to add a timeout to the RunProcess RPC call, because it not a secure and reliable transport channel. 

- The second issue is when IronFrame.Host processes remain orphan (maybe due to a timeout) and never gets terminated. My proposed fix is to add the IF.Host process to the JobObject so that, in case of any future failure, the IF.Host process will get terminate when the JobObject is closed at destroy time.

After some stress testing with this patches, it seems to solve my experienced issues.

I have a core dump of the Containerizer.exe process, but it's pretty big (~400 MiB) to attach here.

As a reference, I could also reproduce this issues with a bosh_lite + windows cell attached and running for 1 - 2 hours the following script that pushes and re-pushes nora:
```sh
#!/bin/bash

while true; do
 cf push snora  -s windows2012R2  -m 128MB  -i 50  -k 100M --no-start -b binary_buildpack
 cf enable-diego snora
 cf push snora
 for i in `seq 1 100`;
 do
  curl -s -o /dev/null -I -w "%{http_code}" http://snora.bosh-lite.com
 done
 cf delete snora -f -r
done
```
I use this scripts to install my windows cell ( https://github.com/stefanschneider/bosh-lite/commit/40029613cb861318f6ba3e8f6674ed5c02253a91 )

Have you guys experienced similar problems on long running environments?
